### PR TITLE
CI: make ethereum_json_rpc and null_example tests optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,6 +146,8 @@ jobs:
     basic-integration-tests:
         needs: release-candidate-deploy
         runs-on: ubuntu-latest
+        # Allow tests that depend on external services or have known transient issues to fail without blocking CI
+        continue-on-error: ${{ contains(fromJSON('["examples/ethereum_json_rpc", "examples/null_example"]'), matrix.example_directories) }}
         env:
             ETHEREUM_URL: ${{ secrets.ETHEREUM_URL }}
             BASILISK_COMPILE_RUST_PYTHON_STDLIB: ${{ matrix.basilisk_source == 'repo' }}


### PR DESCRIPTION
These tests have known external dependency issues that cause spurious CI failures:

- **ethereum_json_rpc**: Requires `ETHEREUM_URL` secret / external Ethereum RPC endpoint that may be unavailable
- **null_example**: Prone to transient dfx download failures (GitHub CDN 502 errors)

Adds `continue-on-error` for these two matrix entries so they still run and report results, but their failure no longer blocks the overall CI status.