### PR TITLE
fix: use unbounded storable for BTreeMap to eliminate 4MB-per-entry overhead

### DIFF
--- a/basilisk/compiler/cpython_canister_template/src/stable_structures.rs
+++ b/basilisk/compiler/cpython_canister_template/src/stable_structures.rs
@@ -32,9 +32,9 @@ thread_local! {
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
 
     // Registries — one per structure kind
-    static MAPS:    RefCell<HashMap<u8, StableBTreeMap<SBytes, SBytes, VM>>> = RefCell::new(HashMap::new());
-    // BTreeSet is emulated via BTreeMap<SBytes, SBytes, VM> with empty values
-    static SETS:    RefCell<HashMap<u8, StableBTreeMap<SBytes, SBytes, VM>>>  = RefCell::new(HashMap::new());
+    static MAPS:    RefCell<HashMap<u8, StableBTreeMap<SBytesU, SBytesU, VM>>> = RefCell::new(HashMap::new());
+    // BTreeSet is emulated via BTreeMap with empty values
+    static SETS:    RefCell<HashMap<u8, StableBTreeMap<SBytesU, SBytesU, VM>>>  = RefCell::new(HashMap::new());
     static VECS:    RefCell<HashMap<u8, StableVec<SBytes, VM>>>              = RefCell::new(HashMap::new());
     static LOGS:    RefCell<HashMap<u8, StableLog<SBytes, VM, VM>>>           = RefCell::new(HashMap::new());
     static CELLS:   RefCell<HashMap<u8, StableCell<SBytes, VM>>>             = RefCell::new(HashMap::new());
@@ -49,8 +49,8 @@ fn get_vm(id: u8) -> VM {
 // Storable wrapper for arbitrary bytes
 // ---------------------------------------------------------------------------
 
-/// Wrapper around `Vec<u8>` that implements `Storable` with variable-length
-/// encoding (max 10 MB per value — generous upper bound).
+/// Bounded storable wrapper — used by StableVec, StableLog, StableCell,
+/// StableMinHeap which require `Bound::Bounded`.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SBytes(pub Vec<u8>);
 
@@ -65,6 +65,23 @@ impl Storable for SBytes {
         max_size: 2_000_000,
         is_fixed_size: false,
     };
+}
+
+/// Unbounded storable wrapper — used by StableBTreeMap / StableBTreeSet.
+/// Variable-length allocation: each entry uses only its actual size + a small
+/// header, avoiding the catastrophic 4 MB-per-entry overhead that Bounded
+/// with max_size=2MB causes.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SBytesU(pub Vec<u8>);
+
+impl Storable for SBytesU {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(&self.0)
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        SBytesU(bytes.to_vec())
+    }
+    const BOUND: Bound = Bound::Unbounded;
 }
 
 // ---------------------------------------------------------------------------
@@ -85,7 +102,7 @@ pub fn smap_insert(id: u8, key: Vec<u8>, value: Vec<u8>) -> Option<Vec<u8>> {
     MAPS.with(|maps| {
         let mut maps = maps.borrow_mut();
         let map = maps.get_mut(&id).expect("smap not initialized");
-        map.insert(SBytes(key), SBytes(value)).map(|v| v.0)
+        map.insert(SBytesU(key), SBytesU(value)).map(|v| v.0)
     })
 }
 
@@ -93,7 +110,7 @@ pub fn smap_get(id: u8, key: &[u8]) -> Option<Vec<u8>> {
     MAPS.with(|maps| {
         let maps = maps.borrow();
         let map = maps.get(&id).expect("smap not initialized");
-        map.get(&SBytes(key.to_vec())).map(|v| v.0)
+        map.get(&SBytesU(key.to_vec())).map(|v| v.0)
     })
 }
 
@@ -101,7 +118,7 @@ pub fn smap_remove(id: u8, key: &[u8]) -> Option<Vec<u8>> {
     MAPS.with(|maps| {
         let mut maps = maps.borrow_mut();
         let map = maps.get_mut(&id).expect("smap not initialized");
-        map.remove(&SBytes(key.to_vec())).map(|v| v.0)
+        map.remove(&SBytesU(key.to_vec())).map(|v| v.0)
     })
 }
 
@@ -109,7 +126,7 @@ pub fn smap_contains_key(id: u8, key: &[u8]) -> bool {
     MAPS.with(|maps| {
         let maps = maps.borrow();
         let map = maps.get(&id).expect("smap not initialized");
-        map.contains_key(&SBytes(key.to_vec()))
+        map.contains_key(&SBytesU(key.to_vec()))
     })
 }
 
@@ -121,7 +138,6 @@ pub fn smap_len(id: u8) -> u64 {
     })
 }
 
-/// Returns all keys as a Vec of byte vectors.
 pub fn smap_keys(id: u8) -> Vec<Vec<u8>> {
     MAPS.with(|maps| {
         let maps = maps.borrow();
@@ -130,7 +146,6 @@ pub fn smap_keys(id: u8) -> Vec<Vec<u8>> {
     })
 }
 
-/// Returns all (key, value) pairs.
 pub fn smap_items(id: u8) -> Vec<(Vec<u8>, Vec<u8>)> {
     MAPS.with(|maps| {
         let maps = maps.borrow();
@@ -159,7 +174,7 @@ pub fn sset_insert(id: u8, key: Vec<u8>) -> bool {
     SETS.with(|sets| {
         let mut sets = sets.borrow_mut();
         let set = sets.get_mut(&id).expect("sset not initialized");
-        set.insert(SBytes(key), SBytes(Vec::new())).is_none()
+        set.insert(SBytesU(key), SBytesU(Vec::new())).is_none()
     })
 }
 
@@ -167,7 +182,7 @@ pub fn sset_remove(id: u8, key: &[u8]) -> bool {
     SETS.with(|sets| {
         let mut sets = sets.borrow_mut();
         let set = sets.get_mut(&id).expect("sset not initialized");
-        set.remove(&SBytes(key.to_vec())).is_some()
+        set.remove(&SBytesU(key.to_vec())).is_some()
     })
 }
 
@@ -175,7 +190,7 @@ pub fn sset_contains(id: u8, key: &[u8]) -> bool {
     SETS.with(|sets| {
         let sets = sets.borrow();
         let set = sets.get(&id).expect("sset not initialized");
-        set.contains_key(&SBytes(key.to_vec()))
+        set.contains_key(&SBytesU(key.to_vec()))
     })
 }
 
@@ -191,7 +206,7 @@ pub fn sset_items(id: u8) -> Vec<Vec<u8>> {
     SETS.with(|sets| {
         let sets = sets.borrow();
         let set = sets.get(&id).expect("sset not initialized");
-        set.iter().map(|(k, _v)| k.0).collect()
+        set.iter().map(|(k, _)| k.0).collect()
     })
 }
 

--- a/docs/MEMORY_MANAGEMENT.md
+++ b/docs/MEMORY_MANAGEMENT.md
@@ -60,7 +60,7 @@ The stable structures system has three layers:
 │  Rust layer  (stable_structures.rs)             │
 │  ic-stable-structures 0.6.x                     │
 │  MemoryManager + per-type registries            │
-│  SBytes wrapper (Storable, Bounded, max 2 MB)   │
+│  SBytesU (Unbounded) / SBytes (Bounded, 2 MB)  │
 ├─────────────────────────────────────────────────┤
 │  IC Stable Memory  (canister-level, survives    │
 │  upgrades)                                      │
@@ -72,8 +72,8 @@ The stable structures system has three layers:
 This module owns all Rust-side state as `thread_local!` registries:
 
 ```rust
-static MAPS:  RefCell<HashMap<u8, StableBTreeMap<SBytes, SBytes, VM>>>
-static SETS:  RefCell<HashMap<u8, StableBTreeMap<SBytes, SBytes, VM>>>  // emulated
+static MAPS:  RefCell<HashMap<u8, StableBTreeMap<SBytesU, SBytesU, VM>>>
+static SETS:  RefCell<HashMap<u8, StableBTreeMap<SBytesU, SBytesU, VM>>>  // emulated
 static VECS:  RefCell<HashMap<u8, StableVec<SBytes, VM>>>
 static LOGS:  RefCell<HashMap<u8, StableLog<SBytes, VM, VM>>>
 static CELLS: RefCell<HashMap<u8, StableCell<SBytes, VM>>>
@@ -82,9 +82,24 @@ static HEAPS: RefCell<HashMap<u8, StableMinHeap<SBytes, VM>>>
 
 Each registry is a `HashMap<u8, Structure>` keyed by `memory_id`. When Python calls `StableBTreeMap(memory_id=5)`, the Rust function `smap_init(5)` checks if memory_id 5 is already in the `MAPS` registry. If not, it obtains a virtual memory and initializes a new `StableBTreeMap` with it.
 
-#### SBytes — the Storable wrapper
+#### Storable wrappers — SBytesU and SBytes
 
-All keys and values are stored as opaque byte blobs using the `SBytes` wrapper:
+Keys and values are stored as opaque byte blobs using two wrapper types:
+
+**`SBytesU`** (unbounded) — used by `StableBTreeMap` and `StableBTreeSet`:
+
+```rust
+pub struct SBytesU(pub Vec<u8>);
+
+impl Storable for SBytesU {
+    const BOUND: Bound = Bound::Unbounded;
+    // ...
+}
+```
+
+With `Bound::Unbounded`, `ic-stable-structures` uses variable-length allocation for BTree entries. Each entry occupies only its actual byte length plus a small header. This avoids the fixed-size slot overhead that bounded types incur.
+
+**`SBytes`** (bounded, max 2 MB) — used by `StableVec`, `StableLog`, `StableCell`, and `StableMinHeap`:
 
 ```rust
 pub struct SBytes(pub Vec<u8>);
@@ -98,7 +113,9 @@ impl Storable for SBytes {
 }
 ```
 
-The `Bounded` trait is required by `StableVec`, `StableLog`, `StableCell`, and `StableMinHeap` in `ic-stable-structures` 0.6.x. Only `StableBTreeMap` supports unbounded types, but a uniform bounded type (2 MB max) is used across all structures for simplicity.
+These structures require `Bound::Bounded` in `ic-stable-structures` 0.6.x. The 2 MB limit accommodates the largest values (file persistence can store files up to 2 MB).
+
+> **Why two types?** Before this split, a single bounded `SBytes` (max 2 MB) was used everywhere. For `StableBTreeMap`, this meant each BTree leaf node slot reserved 4 MB (2 MB key + 2 MB value) regardless of actual data size. A map with 1,000 entries of ~1 KB each would consume ~4 GB of stable memory instead of ~1 MB. Switching BTreeMap to unbounded eliminated this 4,000x space amplification.
 
 ### C FFI bridge (`ic_api.rs`)
 


### PR DESCRIPTION
## Summary

- `StableBTreeMap` and `StableBTreeSet` now use `SBytesU` (`Bound::Unbounded`) instead of `SBytes` (`Bound::Bounded { max_size: 2_000_000 }`).
- The bounded type caused `ic-stable-structures` to reserve **4 MB per entry slot** in BTree leaf nodes regardless of actual data size, leading to catastrophic space amplification (e.g. 715 KB of real data consuming 4.5 GB of stable memory).
- With unbounded types, each entry uses only its actual byte length plus a small pointer header.
- `StableVec`, `StableLog`, `StableCell`, `StableMinHeap` retain the bounded `SBytes` since those structures require `Bound::Bounded`.

## Evidence

Before and after reinstalling the 4 high-burn canisters on staging/demo with this fix:

| Canister | Memory Before | Memory After | Reduction |
|----------|--------------|--------------|-----------|
| staging-realm_installer | 7,349 MB | 33 MB | -99.6% |
| demo-realm_installer | 3,357 MB | 33 MB | -99.0% |
| staging-file_registry | 1,418 MB | 25 MB | -98.3% |
| demo-file_registry | 1,312 MB | 25 MB | -98.1% |

Total idle cycle burn dropped from ~343 TC/day to ~3 TC/day.

## Breaking change

The BTree on-disk format changes between bounded and unbounded. Existing canisters must be **reinstalled** (not upgraded) for the new layout to take effect.

## Test plan

- [x] `cargo check --target wasm32-wasip1` passes
- [x] Template WASM built from source, converted with wasi2ic
- [x] All 4 canisters reinstalled and responding (health/list endpoints verified)
- [ ] Run Basilisk test suite (`pytest`)

Made with [Cursor](https://cursor.com)